### PR TITLE
Add voice temperature remote prototype (MFCC→quantize→packet→BPSK/AWGN→DTW→PID)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,42 @@
-# hello-world
-此存储库用于练习 GitHub 流
-你好，这里是pubstren的第一个仓库
-hhhhhhh
-hhhhhh
+# Voice Temperature Remote
+
+Python-based reference implementation for a **MFCC + DTW** speech command link driving a
+black-box temperature plant with **PID + mode state machine** control.
+
+## Module layout
+
+```
+voice_temp_remote/
+  config.py          # system configuration constants
+  tx_capture.py      # audio capture + simple VAD
+  mfcc_feat.py       # MFCC + CMVN + quantization
+  packet.py          # packet framing + CRC16
+  channel_sim.py     # BPSK + AWGN channel
+  rx_recognize.py    # DTW template matcher
+  plant_temp.py      # temperature plant (black-box internal state)
+  controller.py      # PID + mode/state machine
+  main_tx.py         # sender entry point
+  main_rx.py         # receiver entry point
+  templates/         # pickled template features
+```
+
+## Quick start
+
+1. Capture a command and build a packet:
+
+```bash
+python -m voice_temp_remote.main_tx --duration 1.0
+```
+
+2. Run the receiver with a saved packet and templates file:
+
+```bash
+python -m voice_temp_remote.main_rx packet.bin --templates templates/templates.pkl --ebn0 10
+```
+
+## Notes
+
+- MFCC extraction uses `librosa`.
+- Audio capture uses `sounddevice`.
+- Templates are expected to be stored as a pickle with a dictionary mapping command names
+  to lists of feature arrays.

--- a/voice_temp_remote/__init__.py
+++ b/voice_temp_remote/__init__.py
@@ -1,0 +1,1 @@
+"""Voice temperature remote package."""

--- a/voice_temp_remote/channel_sim.py
+++ b/voice_temp_remote/channel_sim.py
@@ -1,0 +1,40 @@
+"""Simple BPSK + AWGN channel simulation."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def bytes_to_bits(data: bytes) -> np.ndarray:
+    bits = np.unpackbits(np.frombuffer(data, dtype=np.uint8))
+    return bits.astype(np.int8)
+
+
+def bits_to_bytes(bits: np.ndarray) -> bytes:
+    bits = bits.astype(np.uint8)
+    if bits.size % 8 != 0:
+        raise ValueError("bit length must be multiple of 8")
+    return np.packbits(bits).tobytes()
+
+
+def bpsk_modulate(bits: np.ndarray) -> np.ndarray:
+    return np.where(bits == 0, -1.0, 1.0)
+
+
+def bpsk_demodulate(symbols: np.ndarray) -> np.ndarray:
+    return (symbols > 0).astype(np.int8)
+
+
+def awgn_channel(symbols: np.ndarray, eb_n0_db: float) -> np.ndarray:
+    eb_n0 = 10 ** (eb_n0_db / 10)
+    sigma = np.sqrt(1 / (2 * eb_n0))
+    noise = np.random.normal(0, sigma, size=symbols.shape)
+    return symbols + noise
+
+
+def transmit_bpsk_awgn(data: bytes, eb_n0_db: float) -> bytes:
+    bits = bytes_to_bits(data)
+    symbols = bpsk_modulate(bits)
+    noisy = awgn_channel(symbols, eb_n0_db)
+    rx_bits = bpsk_demodulate(noisy)
+    return bits_to_bytes(rx_bits)

--- a/voice_temp_remote/config.py
+++ b/voice_temp_remote/config.py
@@ -1,0 +1,50 @@
+"""Configuration values for the voice temperature remote system."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AudioConfig:
+    sample_rate: int = 16000
+    frame_length_ms: float = 25.0
+    frame_hop_ms: float = 10.0
+    n_mfcc: int = 13
+    use_deltas: bool = True
+
+
+@dataclass(frozen=True)
+class QuantizationConfig:
+    scale: float = 0.1
+    scale_q_multiplier: int = 1000
+
+
+@dataclass(frozen=True)
+class PacketConfig:
+    magic: bytes = b"VT"
+    version: int = 1
+
+
+@dataclass(frozen=True)
+class ControlConfig:
+    dt: float = 0.2
+    initial_setpoint: float = 25.0
+    delta_setpoint: float = 1.0
+    u_min: float = 0.0
+    u_max: float = 1.0
+
+
+@dataclass(frozen=True)
+class PIDConfig:
+    kp: float = 0.6
+    ki: float = 0.04
+    kd: float = 0.02
+
+
+@dataclass(frozen=True)
+class PlantConfig:
+    tau: float = 30.0
+    gain: float = 1.4
+    env_temp: float = 22.0
+    noise_std: float = 0.15

--- a/voice_temp_remote/controller.py
+++ b/voice_temp_remote/controller.py
@@ -1,0 +1,69 @@
+"""PID controller with a simple mode/state machine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from .config import ControlConfig, PIDConfig
+
+
+class Mode(Enum):
+    OFF = "off"
+    ON = "on"
+    HOLD = "hold"
+
+
+@dataclass
+class ControllerState:
+    mode: Mode
+    setpoint: float
+    integral: float
+    prev_error: float
+
+
+class PIDController:
+    def __init__(self, control_cfg: ControlConfig, pid_cfg: PIDConfig) -> None:
+        self._cfg = control_cfg
+        self._pid = pid_cfg
+        self._state = ControllerState(
+            mode=Mode.OFF,
+            setpoint=control_cfg.initial_setpoint,
+            integral=0.0,
+            prev_error=0.0,
+        )
+
+    @property
+    def state(self) -> ControllerState:
+        return self._state
+
+    def apply_command(self, command: str) -> None:
+        if command == "on":
+            self._state.mode = Mode.ON
+        elif command == "off":
+            self._state.mode = Mode.OFF
+        elif command == "hold":
+            self._state.mode = Mode.HOLD
+        elif command == "up":
+            self._state.setpoint += self._cfg.delta_setpoint
+        elif command == "down":
+            self._state.setpoint -= self._cfg.delta_setpoint
+
+    def compute(self, measurement: float) -> float:
+        if self._state.mode == Mode.OFF:
+            self._state.integral = 0.0
+            self._state.prev_error = 0.0
+            return self._cfg.u_min
+
+        error = self._state.setpoint - measurement
+        derivative = (error - self._state.prev_error) / self._cfg.dt
+        u = (
+            self._pid.kp * error
+            + self._pid.ki * self._state.integral
+            + self._pid.kd * derivative
+        )
+        u_clamped = max(self._cfg.u_min, min(self._cfg.u_max, u))
+        if u_clamped == u:
+            self._state.integral += error * self._cfg.dt
+        self._state.prev_error = error
+        return u_clamped

--- a/voice_temp_remote/main_rx.py
+++ b/voice_temp_remote/main_rx.py
@@ -1,0 +1,62 @@
+"""Receive-side entry point: decode, recognize, and control plant."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import pickle
+
+from .channel_sim import transmit_bpsk_awgn
+from .config import ControlConfig, PacketConfig, PIDConfig, PlantConfig, QuantizationConfig
+from .controller import PIDController
+from .mfcc_feat import dequantize_features
+from .packet import unpack_packet
+from .plant_temp import TemperaturePlant
+from .rx_recognize import recognize_command
+
+
+def load_templates(path: pathlib.Path):
+    with path.open("rb") as handle:
+        return pickle.load(handle)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Voice temperature remote RX")
+    parser.add_argument("packet", type=pathlib.Path)
+    parser.add_argument("--templates", type=pathlib.Path, required=True)
+    parser.add_argument("--ebn0", type=float, default=10.0)
+    args = parser.parse_args()
+
+    packet_cfg = PacketConfig()
+    quant_cfg = QuantizationConfig()
+    control_cfg = ControlConfig()
+    pid_cfg = PIDConfig()
+    plant_cfg = PlantConfig()
+
+    raw = args.packet.read_bytes()
+    noisy = transmit_bpsk_awgn(raw, args.ebn0)
+    header, payload = unpack_packet(noisy, packet_cfg)
+    scale = header.scale_q / quant_cfg.scale_q_multiplier
+    features = dequantize_features(payload, scale)
+
+    templates = load_templates(args.templates)
+    result = recognize_command(features, templates, band=40)
+
+    controller = PIDController(control_cfg, pid_cfg)
+    plant = TemperaturePlant(plant_cfg)
+    controller.apply_command("on")
+    controller.apply_command(result.command)
+
+    disturbance = plant.apply_random_disturbance()
+    measurement = plant.step(0.0, control_cfg.dt, disturbance=disturbance)
+    control_u = controller.compute(measurement)
+    measurement = plant.step(control_u, control_cfg.dt)
+
+    print(
+        f"cmd={result.command} dist={result.distance:.2f} "
+        f"T={measurement:.2f} set={controller.state.setpoint:.2f} u={control_u:.2f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/voice_temp_remote/main_tx.py
+++ b/voice_temp_remote/main_tx.py
@@ -1,0 +1,43 @@
+"""Transmit-side entry point: capture audio, extract MFCC, and send packets."""
+
+from __future__ import annotations
+
+import argparse
+
+from .config import AudioConfig, PacketConfig, QuantizationConfig
+from .mfcc_feat import compute_mfcc, quantize_features
+from .packet import PacketHeader, pack_packet
+from .tx_capture import capture_with_vad
+
+
+def build_packet(seq: int, features, scale, packet_cfg, quant_cfg):
+    header = PacketHeader(
+        version=packet_cfg.version,
+        msg_type=0,
+        seq=seq,
+        cmd_id=0,
+        n_frames=features.shape[0],
+        dim=features.shape[1],
+        scale_q=int(scale * quant_cfg.scale_q_multiplier),
+    )
+    return pack_packet(header, features, packet_cfg)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Voice temperature remote TX")
+    parser.add_argument("--duration", type=float, default=1.0)
+    args = parser.parse_args()
+
+    audio_cfg = AudioConfig()
+    quant_cfg = QuantizationConfig()
+    packet_cfg = PacketConfig()
+
+    capture = capture_with_vad(args.duration, audio_cfg)
+    feat = compute_mfcc(capture.audio, audio_cfg)
+    quantized, scale = quantize_features(feat.features, quant_cfg)
+    packet = build_packet(1, quantized, scale, packet_cfg, quant_cfg)
+    print(f"Packet bytes: {len(packet)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/voice_temp_remote/mfcc_feat.py
+++ b/voice_temp_remote/mfcc_feat.py
@@ -1,0 +1,63 @@
+"""MFCC feature extraction and quantization utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+
+from .config import AudioConfig, QuantizationConfig
+
+try:
+    import librosa
+except ImportError:  # pragma: no cover - optional dependency
+    librosa = None
+
+
+@dataclass
+class FeatureResult:
+    features: np.ndarray
+    mean: np.ndarray
+    std: np.ndarray
+
+
+def _require_librosa() -> None:
+    if librosa is None:
+        raise RuntimeError("librosa is required for MFCC extraction")
+
+
+def compute_mfcc(audio: np.ndarray, config: AudioConfig) -> FeatureResult:
+    _require_librosa()
+    frame_length = int(config.sample_rate * config.frame_length_ms / 1000.0)
+    hop_length = int(config.sample_rate * config.frame_hop_ms / 1000.0)
+    mfcc = librosa.feature.mfcc(
+        y=audio.astype(np.float32),
+        sr=config.sample_rate,
+        n_mfcc=config.n_mfcc,
+        n_fft=frame_length,
+        hop_length=hop_length,
+    )
+    if config.use_deltas:
+        delta = librosa.feature.delta(mfcc)
+        delta2 = librosa.feature.delta(mfcc, order=2)
+        stacked = np.vstack([mfcc, delta, delta2])
+    else:
+        stacked = mfcc
+    stacked = stacked.T
+    mean = stacked.mean(axis=0)
+    std = stacked.std(axis=0) + 1e-8
+    norm = (stacked - mean) / std
+    return FeatureResult(features=norm.astype(np.float32), mean=mean, std=std)
+
+
+def quantize_features(
+    features: np.ndarray, config: QuantizationConfig
+) -> Tuple[np.ndarray, float]:
+    scale = float(config.scale)
+    quantized = np.clip(np.round(features / scale), -128, 127).astype(np.int8)
+    return quantized, scale
+
+
+def dequantize_features(quantized: np.ndarray, scale: float) -> np.ndarray:
+    return quantized.astype(np.float32) * float(scale)

--- a/voice_temp_remote/packet.py
+++ b/voice_temp_remote/packet.py
@@ -1,0 +1,95 @@
+"""Packet formatting and CRC utilities."""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+
+from .config import PacketConfig
+
+
+@dataclass
+class PacketHeader:
+    version: int
+    msg_type: int
+    seq: int
+    cmd_id: int
+    n_frames: int
+    dim: int
+    scale_q: int
+
+
+HEADER_FORMAT = ">2sBBH B H B H"
+HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
+CRC_FORMAT = ">H"
+
+
+def crc16(data: bytes) -> int:
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte << 8
+        for _ in range(8):
+            if crc & 0x8000:
+                crc = (crc << 1) ^ 0x1021
+            else:
+                crc <<= 1
+            crc &= 0xFFFF
+    return crc
+
+
+def pack_packet(
+    header: PacketHeader,
+    payload: np.ndarray,
+    packet_cfg: PacketConfig,
+) -> bytes:
+    if payload.dtype != np.int8:
+        raise ValueError("payload must be int8")
+    scale_q = int(round(header.scale_q))
+    header_bytes = struct.pack(
+        HEADER_FORMAT,
+        packet_cfg.magic,
+        header.version,
+        header.msg_type,
+        header.seq,
+        header.cmd_id,
+        header.n_frames,
+        header.dim,
+        scale_q,
+    )
+    payload_bytes = payload.tobytes()
+    crc = crc16(header_bytes + payload_bytes)
+    return header_bytes + payload_bytes + struct.pack(CRC_FORMAT, crc)
+
+
+def unpack_packet(
+    data: bytes, packet_cfg: PacketConfig
+) -> Tuple[PacketHeader, np.ndarray]:
+    if len(data) < HEADER_SIZE + 2:
+        raise ValueError("packet too short")
+    header_values = struct.unpack(HEADER_FORMAT, data[:HEADER_SIZE])
+    magic = header_values[0]
+    if magic != packet_cfg.magic:
+        raise ValueError("invalid magic")
+    header = PacketHeader(
+        version=header_values[1],
+        msg_type=header_values[2],
+        seq=header_values[3],
+        cmd_id=header_values[4],
+        n_frames=header_values[5],
+        dim=header_values[6],
+        scale_q=header_values[7],
+    )
+    payload_size = header.n_frames * header.dim
+    payload_end = HEADER_SIZE + payload_size
+    if len(data) < payload_end + 2:
+        raise ValueError("packet length mismatch")
+    payload_bytes = data[HEADER_SIZE:payload_end]
+    crc_expected = struct.unpack(CRC_FORMAT, data[payload_end : payload_end + 2])[0]
+    crc_actual = crc16(data[:payload_end])
+    if crc_actual != crc_expected:
+        raise ValueError("crc mismatch")
+    payload = np.frombuffer(payload_bytes, dtype=np.int8).reshape(header.n_frames, header.dim)
+    return header, payload

--- a/voice_temp_remote/plant_temp.py
+++ b/voice_temp_remote/plant_temp.py
@@ -1,0 +1,39 @@
+"""Temperature plant model treated as a black box for the controller."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+from .config import PlantConfig
+
+
+@dataclass
+class PlantState:
+    temperature: float
+
+
+class TemperaturePlant:
+    def __init__(self, config: PlantConfig, initial_temp: float | None = None) -> None:
+        self._config = config
+        if initial_temp is None:
+            initial_temp = config.env_temp
+        self._state = PlantState(temperature=initial_temp)
+
+    def step(self, u: float, dt: float, disturbance: float = 0.0) -> float:
+        u = float(np.clip(u, 0.0, 1.0))
+        temp = self._state.temperature
+        dtemp = dt * (
+            -(temp - self._config.env_temp) / self._config.tau
+            + self._config.gain * u
+            + disturbance
+        )
+        temp = temp + dtemp
+        self._state.temperature = temp
+        meas = temp + np.random.normal(0.0, self._config.noise_std)
+        return float(meas)
+
+    def apply_random_disturbance(self, prob: float = 0.05, magnitude: float = -0.5) -> float:
+        if np.random.rand() < prob:
+            return magnitude
+        return 0.0

--- a/voice_temp_remote/rx_recognize.py
+++ b/voice_temp_remote/rx_recognize.py
@@ -1,0 +1,44 @@
+"""DTW-based template matching for command recognition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+
+
+@dataclass
+class RecognitionResult:
+    command: str
+    distance: float
+
+
+def dtw_distance(x: np.ndarray, y: np.ndarray, band: int | None = None) -> float:
+    n, m = x.shape[0], y.shape[0]
+    if band is None:
+        band = max(n, m)
+    band = max(band, abs(n - m))
+    cost = np.full((n + 1, m + 1), np.inf, dtype=np.float64)
+    cost[0, 0] = 0.0
+    for i in range(1, n + 1):
+        j_start = max(1, i - band)
+        j_end = min(m + 1, i + band + 1)
+        for j in range(j_start, j_end):
+            dist = np.linalg.norm(x[i - 1] - y[j - 1])
+            cost[i, j] = dist + min(cost[i - 1, j], cost[i, j - 1], cost[i - 1, j - 1])
+    return float(cost[n, m])
+
+
+def recognize_command(
+    feat: np.ndarray, templates: Dict[str, Iterable[np.ndarray]], band: int | None = None
+) -> RecognitionResult:
+    best_cmd = "unknown"
+    best_dist = float("inf")
+    for cmd, tmpl_list in templates.items():
+        for tmpl in tmpl_list:
+            dist = dtw_distance(feat, tmpl, band=band)
+            if dist < best_dist:
+                best_dist = dist
+                best_cmd = cmd
+    return RecognitionResult(command=best_cmd, distance=best_dist)

--- a/voice_temp_remote/tx_capture.py
+++ b/voice_temp_remote/tx_capture.py
@@ -1,0 +1,58 @@
+"""Audio capture utilities with optional voice activity detection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+try:
+    import sounddevice as sd
+except ImportError:  # pragma: no cover - optional dependency
+    sd = None
+
+from .config import AudioConfig
+
+
+@dataclass
+class CaptureResult:
+    audio: np.ndarray
+    sample_rate: int
+
+
+def _require_sounddevice() -> None:
+    if sd is None:
+        raise RuntimeError("sounddevice is required for audio capture")
+
+
+def record_audio(duration_s: float, config: AudioConfig) -> CaptureResult:
+    _require_sounddevice()
+    audio = sd.rec(
+        int(duration_s * config.sample_rate),
+        samplerate=config.sample_rate,
+        channels=1,
+        dtype="float32",
+    )
+    sd.wait()
+    return CaptureResult(audio=audio.squeeze(axis=-1), sample_rate=config.sample_rate)
+
+
+def simple_vad(audio: np.ndarray, threshold: float = 0.01) -> np.ndarray:
+    if audio.size == 0:
+        return audio
+    mask = np.abs(audio) > threshold
+    if not mask.any():
+        return audio
+    indices = np.where(mask)[0]
+    return audio[indices[0] : indices[-1] + 1]
+
+
+def capture_with_vad(
+    duration_s: float, config: AudioConfig, vad_threshold: Optional[float] = 0.01
+) -> CaptureResult:
+    result = record_audio(duration_s, config)
+    if vad_threshold is None:
+        return result
+    trimmed = simple_vad(result.audio, threshold=vad_threshold)
+    return CaptureResult(audio=trimmed, sample_rate=result.sample_rate)


### PR DESCRIPTION
### Motivation

- Provide a Python reference implementation of a constrained voice-controlled temperature remote following the design: MFCC feature extraction + quantization, packet framing, communication channel, DTW recognition, a black-box temperature plant, and PID/mode control.
- Enable end-to-end experimentation with encoded MFCC payloads over a simulated BPSK+AWGN channel and closed-loop control using only observable temperature measurements.

### Description

- Add configuration and audio utilities in `voice_temp_remote/config.py` and `voice_temp_remote/tx_capture.py` to support MFCC extraction parameters and simple VAD-based capture.
- Implement MFCC extraction, CMVN and int8 quantization in `voice_temp_remote/mfcc_feat.py`, plus corresponding dequantization helper.
- Introduce a self-describing binary packet format with CRC16 in `voice_temp_remote/packet.py` and a BPSK+AWGN channel simulation in `voice_temp_remote/channel_sim.py` to transmit packets as a bitstream.
- Implement DTW template-matching recognition in `voice_temp_remote/rx_recognize.py` and add a template-loading entry to the RX flow.
- Provide a black-box temperature plant model in `voice_temp_remote/plant_temp.py` and a PID controller with a simple mode/state machine in `voice_temp_remote/controller.py` that only reads `T_meas`.
- Add CLI entry points `voice_temp_remote/main_tx.py` and `voice_temp_remote/main_rx.py` to build/send packets and to receive/decode/recognize/control the plant, respectively, and update `README.md` with usage notes.

### Testing

- No automated tests were executed as part of this change.
- Basic file-level sanity was exercised by importing/inspecting the created modules during development, but no unit or integration test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969aba5cad48324933712e6fceffefe)